### PR TITLE
fix for #15 and TB115

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,27 +7,39 @@
     "applications": {
         "gecko": {
             "id": "the_stonehead@hotmail.com",
-            "strict_min_version": "88.0",
-			"strict_max_version": "110.0"
+            "strict_min_version": "115.0",
+            "strict_max_version": "115.*"
         }
     },
-	"background": {
-	  "scripts": [ "scripts/background.js"]
-	},
-    "permissions": [ "menus", "messagesRead", "accountsRead" ],
+    "background": {
+        "scripts": [
+            "scripts/background.js"
+        ]
+    },
+    "permissions": [
+        "menus",
+        "messagesRead",
+        "accountsRead"
+    ],
     "icons": {
         "64": "images/attachment-icon-64.png",
         "32": "images/attachment-icon-32.png",
         "16": "images/attachment-icon-16.png"
     },
-	"experiment_apis": {
-		"attachmentExtractorApi": {
-			"schema": "schema.json",
-			"parent": {
-				"scopes": ["addon_parent"],
-				"paths": [["attachmentExtractorApi"]],
-				"script": "scripts/implementation.js"
-			}
-		}
-	}
+    "experiment_apis": {
+        "attachmentExtractorApi": {
+            "schema": "schema.json",
+            "parent": {
+                "scopes": [
+                    "addon_parent"
+                ],
+                "paths": [
+                    [
+                        "attachmentExtractorApi"
+                    ]
+                ],
+                "script": "scripts/implementation.js"
+            }
+        }
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "applications": {
         "gecko": {
             "id": "the_stonehead@hotmail.com",
-            "strict_min_version": "115.0",
+            "strict_min_version": "102.0",
             "strict_max_version": "115.*"
         }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Attachment Extractor",
     "description": "Extract attachments from selected e-mails!",
-    "version": "1.3",
+    "version": "1.4",
     "author": "TheStonehead",
     "applications": {
         "gecko": {

--- a/schema.json
+++ b/schema.json
@@ -3,25 +3,6 @@
     "namespace": "attachmentExtractorApi",
 	"types": [
 		{
-			"id": "Attachment",
-			"type": "object",
-			"description": "Attachment info",
-			"properties": {
-				"contentType": {
-					"type": "string"
-				},
-				"name": {
-					"type": "string"
-				},
-				"partName": {
-					"type": "string"
-				},
-				"size": {
-					"type": "integer"
-				}
-			}
-		},
-		{
 			"id": "MessageIdWithAttachments",
 			"type": "object",
 			"description": "Message id with attachments",
@@ -39,7 +20,7 @@
 				"attachments": {
 					"type": "array",
 					"items": {
-						"$ref": "Attachment"
+						"$ref": "messages.MessageAttachment"
 					}
 				}
 			}

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -24,7 +24,7 @@ async function onClicked(info, tab){
 	}
 
 	// Get first page of messages
-	let currentPage = await browser.mailTabs.getSelectedMessages(tab.id);
+	let currentPage = info.selectedMessages;
 	if (currentPage.messages.length == 0){
 		browser.attachmentExtractorApi.showAlertToUser("Oops", "No message selected. Please select a message (or multiple) with an attachment.");
 		return;

--- a/scripts/implementation.js
+++ b/scripts/implementation.js
@@ -1,3 +1,5 @@
+var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
+
 var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
     return {
@@ -39,18 +41,18 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 			try {
 				// This doesn't work:
 				// let messenger = Cc["@mozilla.org/messenger;1"].createInstance(Ci.nsIMessenger);
-				let messenger = Services.wm.getMostRecentWindow("mail:3pane").messenger;
-				let neckoURL = {};
+				let window = Services.wm.getMostRecentWindow("mail:3pane");
+				let messenger = window.messenger;
 			
 				// Keep track of used filenames to ensure no overlap by adding _# at the end
 				const usedFilenames= {};
 				for (let msg of messages) {
 					let folder = context.extension.folderManager.get(msg.account, msg.folder);
 					let message = context.extension.messageManager.get(msg.id);
-					let messageUri = folder.baseMessageURI + "#" + message.messageKey;
-					let messageService = messenger.messageServiceFromURI(messageUri);
-					let attachmentUriBase = messageService.getUrlForUri(messageUri, neckoURL, null).spec;
-					
+					let messageUri = folder.getUriForMsg(message);
+					let messageService = MailServices.messageServiceFromURI(messageUri);
+					let attachmentUriBase = messageService.getUrlForUri(messageUri).spec;
+
 					// Detachment data per message
 					let msgTypes= [];
 					let msgAttachmentUrls = [];
@@ -101,10 +103,10 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 						msgMessageUrls.push(messageUri)
 					}
 					types.push(msgTypes);
-					filenames.push(msgFilenames);
-					originalFilenames.push(msgOriginalFilenames);
 					attachmentUrls.push(msgAttachmentUrls);
+					filenames.push(msgFilenames);
 					messageUrls.push(msgMessageUrls);
+					originalFilenames.push(msgOriginalFilenames);
 				}
 				
 				// Notify user about files that can't be saved
@@ -117,13 +119,57 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 				}
 				
 				// messenger.detachAllAttachments throws and exception when attachments from multiple messages are given
-				// Therefore we work around by first saving all of the attachments to a selected folder
-				messenger.saveAllAttachments(
-					types.flat(),
-					attachmentUrls.flat(),
-					filenames.flat(),
-					messageUrls.flat()
-				  );
+				// Therefore we work around by first saving all of the attachments to a selected folder.
+				// There are reports, that saving sometimes fails. Lets save message by message and wait for its completion.
+				let filePicker = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
+				filePicker.init(window, "Save Attachmets", filePicker.modeGetFolder);
+				let selectedFolder = await new Promise(resolve => {
+					filePicker.open(rv => {
+					  if (rv != Ci.nsIFilePicker.returnOK || !filePicker.file) {
+						resolve(null)
+					  } else {
+					  	resolve(filePicker.file);
+					  }
+					});
+				});
+				if (!selectedFolder || !selectedFolder.isDirectory()) {
+					return;
+				}
+
+				for (let m=0; m<messages.length; m++){
+					for (let i=0; i<filenames[m].length; i++) {
+						let filename = filenames[m][i];
+						let attachmentUrl = attachmentUrls[m][i];
+						let type = types[m][i];
+						let messageUrl = messageUrls[m][i];
+						
+						let targetDir = selectedFolder.clone();
+						targetDir.append(filename);
+						let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+						file.initWithPath(targetDir.path);
+						
+						let success = await new Promise(resolve => {
+							let urlListener = {
+								OnStartRunningUrl(url) {},
+								OnStopRunningUrl(url, status) {
+								  resolve(Components.isSuccessCode(status));
+								},
+							  };
+							messenger.saveAttachmentToFile(
+								file,
+								attachmentUrl,
+								messageUrl,
+								type,
+								urlListener
+							);
+						});
+						if (!success) {
+							Services.prompt.alert(null, "Save Attachments", "Could not save attachment, aborting.");
+							return;
+						}
+					}
+				}
+
 				// And then after checking with the user, we delete attachments message by message without further prompts
 				if (Services.prompt.confirm(null, "Are you sure", "Do you wish to delete these attachments from your e-mails? (Irreversible!)\n" + prepareFilesNamesForDisplaying(originalFilenames.flat()).join("\n"))){
 					for (let i in messages){

--- a/scripts/implementation.js
+++ b/scripts/implementation.js
@@ -16,6 +16,7 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 			const messageUrls = [];
 			const deletedFiles = [];
 			
+
 			// Helper inline function for preparing filenames for displaying to the user
 			const prepareFilesNamesForDisplaying = function(filenames) {
 				const filteredFileNames = filenames.map(s=>s.trim()).filter(s=>s.length>0);
@@ -39,18 +40,18 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 			
 			
 			try {
-				// This doesn't work:
-				// let messenger = Cc["@mozilla.org/messenger;1"].createInstance(Ci.nsIMessenger);
 				let window = Services.wm.getMostRecentWindow("mail:3pane");
 				let messenger = window.messenger;
-			
+				// Former is TB115, later is TB102.
+				const messageServiceFromURI = MailServices.messageServiceFromURI || messenger.messageServiceFromURI;
+
 				// Keep track of used filenames to ensure no overlap by adding _# at the end
 				const usedFilenames= {};
 				for (let msg of messages) {
 					let folder = context.extension.folderManager.get(msg.account, msg.folder);
 					let message = context.extension.messageManager.get(msg.id);
 					let messageUri = folder.getUriForMsg(message);
-					let messageService = MailServices.messageServiceFromURI(messageUri);
+					let messageService = messageServiceFromURI(messageUri);
 					let attachmentUriBase = messageService.getUrlForUri(messageUri).spec;
 
 					// Detachment data per message


### PR DESCRIPTION
This tries to fix issue #15 and makes it compatible with TB115.

This PR saves the attachements file by file and waits for completion. I assume the `saveAllAttachments()` method returned before the save process was actually done, and we removed the message before the save has completed. I also did not see the message doubling anymore, which could be another indication of that delete-while-still-saving issue.

A personal note: The downloads API does not allow to download multiple files to the same folder (without asking for each file). This add-on *can* be updated to be a pure WebExtension, after we add the detach attachment method (which is planned for this cycle). The only needed change in behavior is to save all the detached attachments in a single zip file, instead of as individual files. Would that be a compromise you would accept? The file save logic can be completely moved to the background and I would assist, if you need help.

