### PR TITLE
refactor completely to make compatible with TB140 to fix #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Thunderbird add-on for extracting attachments from e-mails
 
 It does two things:
- 1. It saves attachments from selected messages to a folder of your choosing
+ 1. It saves attachments from selected messages to a folder of your choice with an optional user-defined filename pattern.
  2. [Optionally] deletes those attachments from messages
  
  
@@ -13,6 +13,6 @@ This add-on enables you to do it in bulk. I would be careful in selecting a lot 
 
 _Does this delete attachments?_
 
-Only if you want it to. There's a separate menu option for deleting/detaching attachments on selected e-mails.
+Only if you want it to. There's a separate menu option for deleting/extracting attachments on selected e-mails.
 
 See add-on: https://addons.thunderbird.net/en-US/thunderbird/addon/attachment-extractor/

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,13 @@
     "manifest_version": 2,
     "name": "Attachment Extractor",
     "description": "Extract attachments from selected e-mails!",
-    "version": "1.8.2",
+    "version": "1.9.0",
     "author": "TheStonehead",
     "applications": {
         "gecko": {
             "id": "the_stonehead@hotmail.com",
             "strict_min_version": "125.0",
-            "strict_max_version": "130.*"
+            "strict_max_version": "140.*"
         }
     },
     "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
         "gecko": {
             "id": "the_stonehead@hotmail.com",
             "strict_min_version": "125.0",
-            "strict_max_version": "140.*"
+            "strict_max_version": "147.*"
         }
     },
     "background": {

--- a/schema.json
+++ b/schema.json
@@ -24,18 +24,76 @@
 		],
 		"functions": [
 			{
-				"name": "detachAttachmentsFromSelectedMessages",
+				"name": "askUserForFilenameFormat",
 				"type": "function",
-				"description": "Starts detachment process for selected messages.",
+				"description": "Ask the user which format in the filenames should be applied when saving attachments.",
+				"async": true,
+				"parameters": []
+			},
+			{
+				"name": "askUserForDestinationFolder",
+				"type": "function",
+				"description": "Ask the user where the extracted attachments should be saved to.",
+				"async": true,
+				"parameters": []
+			},
+			{
+				"name": "getListLimitedTo",
+				"type": "function",
+				"description": "Reduce a long list to the given number of entries, where last entry tells about more entries to exist.",
+				"async": true,
+				"parameters": [
+				  {
+					"name": "longList",
+					"description": "the list which might be truncated",
+					"type": "array",
+					"items": {
+					  "type": "string"
+					}
+				  },
+				  {
+					"name": "limitTo",
+					"description": "Optional number of entries of the resulting list, defaults to a reasonable value.",
+					"optional": true,
+					"type": "integer"
+				  }
+				]
+			},
+			{
+				"name": "getFilePathForAttachment",
+				"type": "function",
+				"description": "Determines the file path to be used for saving the attachment. It checks whether the filename has been used before and makes it unique by adding a^ counter.",
 				"async": true,
 				"parameters": [
 					{
-						"name": "messages",
-						"type": "array",
-						"description": "The details of the messages with attachments to extract.",
-						"items": {
-							"$ref": "MessageDetails"
-						}
+						"name": "messageId",
+						"type": "integer",
+						"description": "id of the message"
+					},
+					{
+						"name": "attachmentName",
+						"type": "string",
+						"description": "name of the attachment"
+					}
+				]
+			},
+			{
+				"name": "saveFileTo",
+				"type": "function",
+				"description": "Saves a file to a given path.",
+				"async": true,
+				"parameters": [
+					{
+						"name": "file",
+						"type": "object",
+						"isInstanceOf": "File",
+						"additionalProperties": true,
+						"description": "The file."
+					},
+					{
+						"name": "path",
+						"type": "string",
+						"description": "Fully qualified path to file."
 					}
 				]
 			},
@@ -43,7 +101,7 @@
 				"name": "showAlertToUser",
 				"type": "function",
 				"description": "Shows a simple alert pop-up to the user.",
-				"async": false,
+				"async": true,
 				"parameters": [
 					{
 						"name": "title",

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -31,7 +31,7 @@ function findPart(parts, partName) {
 /**
  * Helper function for getting attachment details from a message.
  */
-const getMessageAttachmentDetails = async function(message){
+const getMessageAttachmentDetails = async function(message) {
 	return {
 		message,
 		attachments: await browser.messages.listAttachments(message.id),
@@ -39,12 +39,8 @@ const getMessageAttachmentDetails = async function(message){
 	};
 }
 
-async function onClicked(info, tab){
-	if (info.menuItemId != "extract-attachments" && info.menuItemId != "delete-attachments") {
-		return;
-	}
-	
-	var allMessageAttachmentDetails = [];
+async function getAttachmentDetailsOfSelectedMessages(info) {
+	let allMessageAttachmentDetails = [];
 
 	// Get first page of messages
 	let currentPage = info.selectedMessages;
@@ -52,71 +48,158 @@ async function onClicked(info, tab){
 		browser.attachmentExtractorApi.showAlertToUser("Oops", "No message selected. Please select a message (or multiple) with an attachment.");
 		return;
 	}
-	
+
 	// Iterate through the messages
-	for (let m of currentPage.messages) {
+	for (const m of currentPage.messages) {
 		allMessageAttachmentDetails.push(await getMessageAttachmentDetails(m));
 	}
 	// As long as there is an ID, more pages can be fetched
 	while (currentPage.id) {
 		currentPage = await browser.messages.continueList(currentPage.id);
-		for (let m of currentPage.messages) {
+		for (const m of currentPage.messages) {
 			allMessageAttachmentDetails.push(await getMessageAttachmentDetails(m));
 		}
 	}
 
-	if (info.menuItemId == "extract-attachments") {
-		// Call Experiment API to detach attachments from selected messages
-		await browser.attachmentExtractorApi.detachAttachmentsFromSelectedMessages(
-			allMessageAttachmentDetails
+	return allMessageAttachmentDetails;
+}
+
+async function getMessagesWithProcessableAttachments(allMessageAttachmentDetails) {
+	return allMessageAttachmentDetails.flatMap(d => {
+		if (d.message.external) {
+			return [];
+		}
+		const processableAttachments = d.attachments.flatMap(a => {
+			// Bug 1910336. This information should be exposed on the
+			// attachments object directly, we should not have to search the
+			// full mime details.
+			const part = findPart(d.full.parts, a.partName);
+			return (
+				!part ||
+				part.contentType == "text/x-moz-deleted" ||
+				!part.headers ||
+				part.headers["x-mozilla-external-attachment-url"]
+			) ? [] : [a]
+		});
+		return processableAttachments.length > 0
+			? [{ message: d.message, attachments: processableAttachments }]
+			: []
+	});
+}
+
+function getActionText(action) {
+	switch (action) {
+		case "extract-attachments":
+			return "extractable";
+		case "delete-attachments":
+			return "deletable";
+		default:
+			return "processable";
+	}
+}
+
+async function checkProcessableAttachments(allMessageAttachmentDetails, processableAttachmentDetails, action) {
+	if (processableAttachmentDetails.length == 0) {
+		browser.attachmentExtractorApi.showAlertToUser(
+			"Oops",
+			`No ${action} attachments found in selected messages.`
+		);
+		return false;
+	}
+	if (processableAttachmentDetails.length < allMessageAttachmentDetails.length) {
+		await browser.attachmentExtractorApi.showAlertToUser(
+			"Info",
+			`Only ${processableAttachmentDetails.length} of your ${allMessageAttachmentDetails.length} selected messages contain ${action} attachments.`
 		);
 	}
-	else if (info.menuItemId == "delete-attachments") {
-		const deletableAttachmentDetails = allMessageAttachmentDetails.flatMap(d => {
-			if (d.message.external) {
-				return [];
+	return true;
+}
+
+async function onClicked(info, tab){
+	if (info.menuItemId != "extract-attachments" && info.menuItemId != "delete-attachments") {
+		return;
+	}
+
+	const allMessageAttachmentDetails = await getAttachmentDetailsOfSelectedMessages(info);
+	const processableAttachmentDetails = await getMessagesWithProcessableAttachments(allMessageAttachmentDetails);
+
+	if (!await checkProcessableAttachments(allMessageAttachmentDetails, processableAttachmentDetails, getActionText(info.menuItemId))) {
+		return;
+	}
+
+	if (info.menuItemId == "extract-attachments") {
+		// Call several methods in Experiment API to extract attachments from selected messages
+		try {
+			// Ask user for preferred attachment filename format
+			await browser.attachmentExtractorApi.askUserForFilenameFormat();
+
+			// // Notify user about files that can't be saved
+			// if (deletedFiles.length > 0) {
+			// 	browser.attachmentExtractorApi.showAlertToUser("Some files can't be saved", "These files have already been deleted and cannot be saved:\n" + prepareFilesNamesForDisplaying(deletedFiles.flat()).join("\n"));
+			// 	// Don't continue if all of the files are already deleted
+			// 	if (types.flat().length == 0) {
+			// 		return;
+			// 	}
+			// }
+
+			if (!await browser.attachmentExtractorApi.askUserForDestinationFolder())
+			{
+				// console.debug("askUserForDestinationFolder did not return a valid folder.");
+				return;
 			}
-			const deletableAttachments = d.attachments.flatMap(a => {
-				// Bug 1910336. This information should be exposed on the
-				// attachments object directly, we should not have to search the
-				// full mime details.
-				const part = findPart(d.full.parts, a.partName);
-				return (
-					!part ||
-					part.contentType == "text/x-moz-deleted" ||
-					!part.headers ||
-					part.headers["x-mozilla-external-attachment-url"]
-				) ? [] : [a]
-			});
-			return deletableAttachments.length > 0
-				? [{ message: d.message, attachments: deletableAttachments }]
-				: []
-		});
-		if (deletableAttachmentDetails.length == 0) {
-			browser.attachmentExtractorApi.showAlertToUser(
-				"Oops",
-				"No deletable attachments found."
-			);
-			return;
+
+			let break_loop = false;
+			let counterSavedAttachments = 0;
+			for (const messageDetail of processableAttachmentDetails) {
+				for (const attachment of messageDetail.attachments) {
+					// read attachment as file
+					const attachedFile = await browser.messages.getAttachmentFile(
+						messageDetail.message.id,
+						attachment.partName
+					)
+					const filePath = await browser.attachmentExtractorApi.getFilePathForAttachment(messageDetail.message.id, attachment.name);
+
+					const success = await browser.attachmentExtractorApi.saveFileTo(attachedFile, filePath);
+					if (success) {
+						counterSavedAttachments++;
+					}
+					else if (!await browser.attachmentExtractorApi.showPromptToUser("Save Attachments", "Could not save attachment. Do you still want to continue?")) {
+						break_loop = true;
+						break;
+					}
+				}
+				if (break_loop) {
+					break;
+				}
+			}
+			browser.attachmentExtractorApi.showAlertToUser("Save Attachments", `In total ${counterSavedAttachments} attachments have been saved. Please check the selected folder.`);
 		}
+		catch (ex) {
+			console.error(ex.toString());
+			browser.attachmentExtractorApi.showAlertToUser("Error", ex.toString());
+		}
+	}
+	else if (info.menuItemId == "delete-attachments") {
+		listAttachmentsNames = processableAttachmentDetails.flatMap(d => d.attachments.map(a => a.name));
 		if (await browser.attachmentExtractorApi.showPromptToUser(
-				`Delete attachments`, 
+				`Delete attachments`,
 				`Do you wish to delete these attachments from your e-mails? (Irreversible!)\n - ${
-					deletableAttachmentDetails.map(d => d.attachments.map(a => a.name)).flat().join("\n - ")
+					(await browser.attachmentExtractorApi.getListLimitedTo(listAttachmentsNames)).join("\n - ")
 				}`
 		)) {
-			for (let messageDetail of deletableAttachmentDetails) {
+			for (const messageDetail of processableAttachmentDetails) {
 				await browser.messages.deleteAttachments(
 					messageDetail.message.id,
 					messageDetail.attachments.map(a => a.partName)
 				);
 			}
-			browser.attachmentExtractorApi.showAlertToUser("Delete attachments", "The requested attachments have been deleted.");
+			browser.attachmentExtractorApi.showAlertToUser("Delete attachments", "The attachments of the selected e-mails have been deleted as requested.");
 		}
 	} else {
+		console.warn(`Provided action '${info.menuItemId}' is not implemented.`);
 		browser.attachmentExtractorApi.showAlertToUser("Oops", "Unknown action.");
 	}
-	
+
 }
 
 function onCreated() {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -16,7 +16,7 @@ browser.menus.onClicked.addListener(onClicked);
  * Helper function to find the full mime details of a part.
  */
 function findPart(parts, partName) {
-	for (let part of parts || []) {
+	for (const part of parts || []) {
 		if (part.partName == partName) {
 			return part;
 		}
@@ -32,10 +32,17 @@ function findPart(parts, partName) {
  * Helper function for getting attachment details from a message.
  */
 const getMessageAttachmentDetails = async function(message) {
+	const messageDetails = `for message ${message.date.toLocaleString()} "${message.subject}"`;
 	return {
 		message,
-		attachments: await browser.messages.listAttachments(message.id),
-		full: await browser.messages.getFull(message.id),
+		attachments: await browser.messages.listAttachments(message.id).catch(e => {
+			console.warn(`Failed to list attachments ${messageDetails}:`, e);
+			return [];
+		}),
+		full: await browser.messages.getFull(message.id).catch(e => {
+			console.warn(`Failed to get full message ${messageDetails}:`, e);
+			return null;
+		}),
 	};
 }
 
@@ -44,7 +51,7 @@ async function getAttachmentDetailsOfSelectedMessages(info) {
 
 	// Get first page of messages
 	let currentPage = info.selectedMessages;
-	if (currentPage.messages.length == 0){
+	if (currentPage.messages.length == 0) {
 		browser.attachmentExtractorApi.showAlertToUser("Oops", "No message selected. Please select a message (or multiple) with an attachment.");
 		return;
 	}

--- a/scripts/implementation.js
+++ b/scripts/implementation.js
@@ -1,190 +1,121 @@
-var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
+const { MailServices } = ChromeUtils.importESModule("resource:///modules/MailServices.sys.mjs");
 
 var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 	getAPI(context) {
 		// Constants
 		const MAX_FILENAMES_FOR_DIALOG = 20;
 
+		let useTemplate = false;
+		let filenameFormat = { value: "%date%_%fromMail%_%subject%_%filename%" };
+		let selectedFolder = null;
+		let usedFilenames = {};
 
 		// Helper inline function for preparing filenames for displaying to the user
-		const prepareFilesNamesForDisplaying = function (filenames) {
-			const filteredFileNames = filenames.map(s => s.trim()).filter(s => s.length > 0);
-			if (filteredFileNames.length > MAX_FILENAMES_FOR_DIALOG) {
-				const slicedFileNames = filteredFileNames.slice(0, MAX_FILENAMES_FOR_DIALOG);
-				slicedFileNames.push(`and ${filteredFileNames.length - MAX_FILENAMES_FOR_DIALOG} more`);
+		const prepareFilesNamesForDisplaying = function(filenames, max_filenames) {
+			// filter non-empty filenames and deduplicate the list
+			const filteredFileNames = [...new Set(filenames.map(s => s.trim()).filter(s => s.length > 0))];
+			if (filteredFileNames.length > max_filenames) {
+				const slicedFileNames = filteredFileNames.slice(0, max_filenames);
+				slicedFileNames.push(`and ${filteredFileNames.length - max_filenames} more`);
 				return slicedFileNames;
+			}
+			return filteredFileNames;
+		};
+
+		const getFilenameForAttachment = function(messageId, attachmentName) {
+			// Handle filename
+			let filename = filenameFormat.value;
+			const [_, filenameWithoutExtension, filenameExtension] = attachmentName.match(/(.*)(\..*)$/) || [null, attachmentName, ""];
+			if (useTemplate) {
+				const message = context.extension.messageManager.get(messageId);
+				const authorRegex = /(.*)?<(.*)>/;
+				const [_, authorName, authorMail] = message.mime2DecodedAuthor.match(authorRegex) || [null, null, message.mime2DecodedAuthor];
+				const [messageDate, messageTime] = (new Date(message.date / 1000)).toISOString().split("T");
+				filename = filename
+					.replace("%date%", messageDate)
+					.replace("%time%", messageTime)
+					.replace("%subject%", message.mime2DecodedSubject)
+					.replace("%fromName%", authorName ? authorName.trim() : authorMail.trim())
+					.replace("%fromMail%", authorMail.trim())
+					.replace("%filename%", filenameWithoutExtension);
 			} else {
-				return filteredFileNames;
+				filename = filenameWithoutExtension;
 			}
+
+			// Check if the same filename has already been added to the collection and add appropriate number
+			const targetFilename = encodeURI(filename + filenameExtension);
+			const usedFilenameCount = usedFilenames[targetFilename] || 0;
+			usedFilenames[targetFilename] = usedFilenameCount + 1;
+			if (usedFilenameCount > 0) {
+				// if name has already been used, add counter to make it unique
+				return encodeURI(filename + "_" + usedFilenameCount + filenameExtension);
+			}
+			return targetFilename;
 		};
 
-		const processMessages = function(messagesDetails, filenameFormat, useTemplate, messageServiceFromURI) {
-			const usedFilenames = {};
-			const types = [];
-			const attachmentUrls = [];
-			const filenames = [];
-			const originalFilenames = [];
-			const messageUrls = [];
-			const deletedFiles = [];
-
-			for (let messageDetails of messagesDetails) {
-				let msg = messageDetails.message;
-				let folder = context.extension.folderManager.get(msg.folder.accountId, msg.folder.path);
-				let message = context.extension.messageManager.get(msg.id);
-				let messageUri = folder.getUriForMsg(message);
-				let messageService = messageServiceFromURI(messageUri);
-				let attachmentUriBase = messageService.getUrlForUri(messageUri).spec;
-
-				// Detachment data per message
-				let msgTypes = [];
-				let msgAttachmentUrls = [];
-				let msgFilenames = [];
-				let msgOriginalFilenames = [];
-				let msgMessageUrls = [];
-
-				for (let attachment of messageDetails.attachments) {
-					// If the attachment is already deleted, skip from processing
-					if (attachment.contentType == "text/x-moz-deleted") {
-						deletedFiles.push(attachment.name);
-						continue;
-					}
-
-					// Handle filename
-					let filename = filenameFormat.value;
-					let [_, filenameWithoutExtension, filenameExtension] = attachment.name.match(/(.*)(\..*)$/) || [null, attachment.name, ""];
-					if (useTemplate) {
-						const authorRegex = /(.*)?<(.*)>/;
-						let [_, authorName, authorMail] = message.mime2DecodedAuthor.match(authorRegex) || [null, null, message.mime2DecodedAuthor];
-						let [messageDate, messageTime] = (new Date(message.date / 1000)).toISOString().split("T");
-						filename = filename
-							.replace("%date%", messageDate)
-							.replace("%time%", messageTime)
-							.replace("%subject%", message.mime2DecodedSubject)
-							.replace("%fromName%", authorName ? authorName.trim() : authorMail.trim())
-							.replace("%fromMail%", authorMail.trim())
-							.replace("%filename%", filenameWithoutExtension);
-					} else {
-						filename = filenameWithoutExtension;
-					}
-
-					// Check if the same filename has already been added to the collection and add appropriate number	
-					let usedFilenameCount = usedFilenames[encodeURI(filename + filenameExtension)];
-					if (usedFilenameCount) {
-						let adjustedFilename = filename;
-						msgFilenames.push(encodeURI(adjustedFilename + "_" + usedFilenameCount + filenameExtension));
-					}
-					else {
-						msgFilenames.push(encodeURI(filename + filenameExtension));
-					}
-					msgOriginalFilenames.push(encodeURI(attachment.name)); //Save original attachment filename to be able to delete them afterwards
-					usedFilenames[encodeURI(filename + filenameExtension)] = (usedFilenameCount || 0) + 1;
-
-					// Handle content type, attachment and message urls
-					msgTypes.push(attachment.contentType);
-					msgAttachmentUrls.push(attachmentUriBase + (attachmentUriBase.indexOf('?') >= 0 ? "&" : "?") + `part=${attachment.partName}&filename=${encodeURI(attachment.name)}`);
-					msgMessageUrls.push(messageUri)
-				}
-				types.push(msgTypes);
-				attachmentUrls.push(msgAttachmentUrls);
-				filenames.push(msgFilenames);
-				messageUrls.push(msgMessageUrls);
-				originalFilenames.push(msgOriginalFilenames);
-			}
-			return [types, attachmentUrls, filenames, messageUrls, originalFilenames, deletedFiles];
-		};
 
 		return {
 			attachmentExtractorApi: {
-				async detachAttachmentsFromSelectedMessages(messagesDetails) {
-					// Ask user for preferred attachment filename format
-					let filenameFormat = { value: "%date%_%fromMail%_%subject%_%filename%" };
-					const useTemplate = Services.prompt.prompt(null, "Input your preferred filename template", "Placeholders you can use: %date%, %time%, %fromMail%, %subject%, %filename%. Press Cancel if you want to use just the original filenames.", filenameFormat, null, {});
-					if (!useTemplate) {
-						return
+				async getListLimitedTo(longList, limitTo) {
+					return prepareFilesNamesForDisplaying(longList, limitTo || MAX_FILENAMES_FOR_DIALOG);
+				},
+				async saveFileTo(file, filePath) {
+					// console.debug(`Save filePath as ${filePath}`);
+					try {
+						if (await IOUtils.exists(filePath)) {
+							if (!Services.prompt.confirm(null, "Are you sure?", `File '${filePath}' already exists.\nDo you want to overwrite the file over there?`)) {
+								return false;
+							}
+							console.warn(`Overwriting of file '${filePath}' has been confirmed by user.`)
+						}
+
+						const byteArray = await file.bytes();
+						// console.debug(`read file content into byte array of size ${byteArray.byteLength}.`);
+
+						// save bytes to file
+						const success = await IOUtils.write(filePath, byteArray);
+						return success;
 					}
+					catch (ex) {
+						Services.prompt.alert(null, `Exception in saveFileTo for file ${filePath}:`, ex.toString());
+				 		return false;
+					}
+				},
+				async askUserForFilenameFormat() {
+					// Ask user for preferred attachment filename format
+					useTemplate = Services.prompt.prompt(null, "Input your preferred filename template", "Placeholders you can use: %date%, %time%, %fromMail%, %subject%, %filename%. Press Cancel if you want to use just the original filenames.", filenameFormat, null, {});
 
 					if (!filenameFormat.value) {
 						Services.prompt.alert(null, "Warning", "You have to enter a template for your files or press Cancel.");
 						return;
 					}
-
-
-					try {
-						let window = Services.wm.getMostRecentWindow("mail:3pane");
-						let messenger = window.messenger;
-						// Former is TB115, later is TB102.
-						const messageServiceFromURI = MailServices.messageServiceFromURI || messenger.messageServiceFromURI;
-
-						// Keep track of used filenames to ensure no overlap by adding _# at the end
-						const [types, attachmentUrls, filenames, messageUrls, originalFilenames, deletedFiles] = processMessages(messagesDetails, filenameFormat, useTemplate, messageServiceFromURI);
-
-						// Notify user about files that can't be saved
-						if (deletedFiles.length > 0) {
-							Services.prompt.alert(null, "Some files can't be saved", "These files have already been deleted and cannot be saved:\n" + prepareFilesNamesForDisplaying(deletedFiles.flat()).join("\n"));
-							// Don't continue if all of the files are already deleted
-							if (types.flat().length == 0) {
-								return;
-							}
-						}
-
-						// messenger.detachAllAttachments throws and exception when attachments from multiple messages are given
-						// Therefore we work around by first saving all of the attachments to a selected folder.
-						// There are reports, that saving sometimes fails. Lets save message by message and wait for its completion.
-						let filePicker = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
-						filePicker.init(window.browsingContext, "Save Attachmets", filePicker.modeGetFolder);
-						let selectedFolder = await new Promise(resolve => {
-							filePicker.open(rv => {
-								if (rv != Ci.nsIFilePicker.returnOK || !filePicker.file) {
-									resolve(null)
-								} else {
-									resolve(filePicker.file);
-								}
-							});
-						});
-						if (!selectedFolder || !selectedFolder.isDirectory()) {
-							return;
-						}
-
-						for (let m = 0; m < messagesDetails.length; m++) {
-							for (let i = 0; i < filenames[m].length; i++) {
-								let filename = filenames[m][i];
-								let attachmentUrl = attachmentUrls[m][i];
-								let type = types[m][i];
-								let messageUrl = messageUrls[m][i];
-
-								let targetDir = selectedFolder.clone();
-								targetDir.append(decodeURIComponent(filename).replace(/[\\/:\*\?\"<>|]/g, "_"));
-								let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
-								file.initWithPath(targetDir.path);
-
-								let success = await new Promise(resolve => {
-									let urlListener = {
-										OnStartRunningUrl(url) { },
-										OnStopRunningUrl(url, status) {
-											resolve(Components.isSuccessCode(status));
-										},
-									};
-									messenger.saveAttachmentToFile(
-										file,
-										attachmentUrl,
-										messageUrl,
-										type,
-										urlListener
-									);
-								});
-								if (!success) {
-									Services.prompt.alert(null, "Save Attachments", "Could not save attachment, aborting.");
-									return;
-								}
-							}
-						}
-						Services.prompt.alert(null, "Save Attachments", "Attachments saved. Please check the selected folder.");
-					}
-					catch (ex) {
-						Services.wm.getMostRecentWindow("mail:3pane").alert("Error: " + ex.toString());
-					}
 				},
-				showAlertToUser(title, text) {
+				async askUserForDestinationFolder() {
+					const previousPath = (selectedFolder ? selectedFolder.path : "");
+					const window = Services.wm.getMostRecentWindow("mail:3pane");
+					let filePicker = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
+					filePicker.init(window.browsingContext, "Save Attachments", filePicker.modeGetFolder);
+					selectedFolder = await new Promise(resolve => {
+						filePicker.open(rv => {
+							if (rv != Ci.nsIFilePicker.returnOK || !filePicker.file) {
+								resolve(null)
+							} else {
+								resolve(filePicker.file);
+							}
+						});
+					});
+					if (selectedFolder && (selectedFolder.path != previousPath))
+					{
+						// reset filenames for collision check
+						usedFilenames = {};
+					}
+					return (selectedFolder && selectedFolder.isDirectory());
+				},
+				async getFilePathForAttachment(messageId, attachmentName) {
+					const filename = getFilenameForAttachment(messageId, attachmentName);
+					return PathUtils.join(selectedFolder.path, decodeURIComponent(filename).replace(/[\\/:\*\?\"<>|]/g, "_"));
+				},
+				async showAlertToUser(title, text) {
 					try {
 						Services.prompt.alert(null, title, text);
 					}
@@ -192,7 +123,7 @@ var attachmentExtractorApi = class extends ExtensionCommon.ExtensionAPI {
 						Services.wm.getMostRecentWindow("mail:3pane").alert("Error: " + ex.toString());
 					}
 				},
-				showPromptToUser(title, text) {
+				async showPromptToUser(title, text) {
 					try {
 						return Services.prompt.confirm(null, title, text);
 					}


### PR DESCRIPTION
Code has been completely refactored to work with Thunderbird 140 to fix #35.
Backward compatibility has not been tested.
The PR comprises the following changes:
- modularize for reusability
- move crucial parts to Experiment API
- improve const correctness
- keep almost all functionality of 1.8.2, only remove listing of non-extractable attachments
- require confirmation by user before overwriting files during extraction
- provide more details to user, such as number of extracted attachments
- deduplicate listing of files to be deleted
- fixes #27 to use filename when canceling template pattern for filenames
- addresses issues with wording to partly fix #29
